### PR TITLE
Fix DAO date type ambiguity

### DIFF
--- a/dao/DiagnosisDAO.java
+++ b/dao/DiagnosisDAO.java
@@ -1,7 +1,8 @@
 package dao;
 
 import java.sql.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import model.Diagnosis;
 
@@ -74,7 +75,7 @@ public class DiagnosisDAO {
             int patientId = rs.getInt("patient_id");
             int doctorId = rs.getInt("doctor_id");
             int diseaseId = rs.getInt("disease_id");
-            Date dateDiagnosis = rs.getDate("date_diagnosis");
+            java.sql.Date dateDiagnosis = rs.getDate("date_diagnosis");
             String notes = rs.getString("notes");
             diagnosises.add(new Diagnosis(id, patientId, doctorId, diseaseId, dateDiagnosis, notes));
         }
@@ -92,7 +93,7 @@ public class DiagnosisDAO {
             int patientId = rs.getInt("patient_id");
             int doctorId = rs.getInt("doctor_id");
             int diseaseId = rs.getInt("disease_id");
-            Date dateDiagnosis = rs.getDate("date_diagnosis");
+            java.sql.Date dateDiagnosis = rs.getDate("date_diagnosis");
             String notes = rs.getString("notes");
             return new Diagnosis(id, patientId, doctorId, diseaseId, dateDiagnosis, notes);
         }

--- a/dao/DiseaseDAO.java
+++ b/dao/DiseaseDAO.java
@@ -1,7 +1,8 @@
 package dao;
 
 import java.sql.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import model.Disease;
 

--- a/dao/LabResultDAO.java
+++ b/dao/LabResultDAO.java
@@ -1,7 +1,8 @@
 package dao;
 
 import java.sql.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import model.LabResult;
 
@@ -78,7 +79,7 @@ public class LabResultDAO {
             int patientId = rs.getInt("patient_id");
             int procedureId = rs.getInt("procedure_id");
             String resultText = rs.getString("result");
-            Date date = rs.getDate("date");
+            java.sql.Date date = rs.getDate("date");
             labResults.add(new LabResult(id, orderingPhysicianId, patientId, procedureId, resultText, date));
         }
         return labResults;
@@ -99,7 +100,7 @@ public class LabResultDAO {
             int patientId = rs.getInt("patient_id");
             int procedureId = rs.getInt("procedure_id");
             String resultText = rs.getString("result");
-            Date date = rs.getDate("date");
+            java.sql.Date date = rs.getDate("date");
             return new LabResult(id, orderingPhysicianId, patientId, procedureId, resultText, date);
         }
         return null;

--- a/dao/MedicalHistoryDAO.java
+++ b/dao/MedicalHistoryDAO.java
@@ -1,7 +1,8 @@
 package dao;
 
 import java.sql.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import model.MedicalHistory;
 
@@ -91,7 +92,7 @@ public class MedicalHistoryDAO {
             Integer doctorId = rs.getObject("doctor_id") != null ? rs.getInt("doctor_id") : null;
             Integer conditionId = rs.getObject("condition_id") != null ? rs.getInt("condition_id") : null;
             String description = rs.getString("description");
-            Date dateRecorded = rs.getDate("date_recorded");
+            java.sql.Date dateRecorded = rs.getDate("date_recorded");
 
             medicalHistorys.add(new MedicalHistory(id, patientId, doctorId, conditionId, description, dateRecorded));
         }
@@ -110,7 +111,7 @@ public class MedicalHistoryDAO {
             Integer doctorId = rs.getObject("doctor_id") != null ? rs.getInt("doctor_id") : null;
             Integer conditionId = rs.getObject("condition_id") != null ? rs.getInt("condition_id") : null;
             String description = rs.getString("description");
-            Date dateRecorded = rs.getDate("date_recorded");
+            java.sql.Date dateRecorded = rs.getDate("date_recorded");
 
             return new MedicalHistory(id, patientId, doctorId, conditionId, description, dateRecorded);
         }

--- a/dao/PatientDAO.java
+++ b/dao/PatientDAO.java
@@ -1,7 +1,8 @@
 package dao;
 
 import java.sql.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 import model.Patient;
 
@@ -75,7 +76,7 @@ public class PatientDAO {
             String firstName = rs.getString("first_name");
             String lastName = rs.getString("last_name");
             String gender = rs.getString("gender");
-            Date dob = rs.getDate("date_of_birth");
+            java.sql.Date dob = rs.getDate("date_of_birth");
 
             patients.add(new Patient(id, firstName, lastName, gender, dob));
         }
@@ -93,7 +94,7 @@ public class PatientDAO {
             String firstName = rs.getString("first_name");
             String lastName = rs.getString("last_name");
             String gender = rs.getString("gender");
-            Date dob = rs.getDate("date_of_birth");
+            java.sql.Date dob = rs.getDate("date_of_birth");
 
             return new Patient(id, firstName, lastName, gender, dob);
         }


### PR DESCRIPTION
## Summary
- replace wildcard `java.util` imports with specific classes to avoid bringing in `java.util.Date`
- explicitly use `java.sql.Date` when reading dates from `ResultSet`
